### PR TITLE
FEATURE: add configuration option to use custom form factories

### DIFF
--- a/Classes/ViewHelpers/JsonConfigurationViewHelper.php
+++ b/Classes/ViewHelpers/JsonConfigurationViewHelper.php
@@ -12,8 +12,14 @@ namespace Neos\Form\YamlBuilder\ViewHelpers;
  */
 
 use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Mvc\Exception\NoSuchArgumentException;
+use Neos\Flow\Mvc\Routing\Exception\MissingActionNameException;
+use Neos\Flow\ResourceManagement\ResourceManager;
+use Neos\Flow\Security\Context;
 use Neos\FluidAdaptor\Core\ViewHelper\AbstractViewHelper;
 use Neos\FluidAdaptor\Core\ViewHelper\Exception;
+use Neos\Form\Exception\PresetNotFoundException;
+use Neos\Form\Factory\ArrayFormFactory;
 use Neos\Form\Utility\SupertypeResolver;
 
 /**
@@ -28,28 +34,42 @@ class JsonConfigurationViewHelper extends AbstractViewHelper
 
     /**
      * @Flow\Inject
-     * @var \Neos\Flow\ResourceManagement\ResourceManager
+     * @var ResourceManager
      */
     protected $resourceManager;
 
     /**
      * @Flow\Inject
-     * @var \Neos\Form\Factory\ArrayFormFactory
+     * @var ArrayFormFactory
      */
     protected $formBuilderFactory;
 
     /**
      * @Flow\Inject
-     * @var \Neos\Flow\Security\Context
+     * @var Context
      */
     protected $securityContext;
 
     /**
-     * @param string $presetName
-     * @return string
+     * @throws Exception
      */
-    public function render($presetName = 'default')
+    public function initializeArguments()
     {
+        $this->registerArgument('presetName', 'string', 'preset name of the form preset configuration', false, 'default');
+        parent::initializeArguments();
+    }
+
+    /**
+     * @return string
+     * @throws Exception
+     * @throws \Neos\Flow\Http\Exception
+     * @throws NoSuchArgumentException
+     * @throws MissingActionNameException
+     * @throws PresetNotFoundException
+     */
+    public function render()
+    {
+        $presetName = $this->arguments['presetName'];
         $mergedConfiguration = [];
 
         $presetConfiguration = $this->formBuilderFactory->getPresetConfiguration($presetName);
@@ -105,7 +125,7 @@ class JsonConfigurationViewHelper extends AbstractViewHelper
     /**
      * @param string $resourcePath
      * @return string
-     * @throws \Neos\FluidAdaptor\Core\ViewHelper\Exception
+     * @throws Exception
      */
     protected function resolveResourcePath($resourcePath)
     {

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -413,3 +413,6 @@ Neos:
                       label: 'Number of submitted values'
                       sorting: 100
                       viewName: 'Neos.Form.YamlBuilder.View.ElementOptionsPanel.Editor.ValidatorEditor.MinimumMaximumValidatorEditor'
+
+        #formFactories:
+          #myFormPersitenceIdentifier: '\MyVendor\MyPackage\PathTo\MyFormFactory'

--- a/README.md
+++ b/README.md
@@ -578,7 +578,7 @@ Now, you only need to include the appropriate Handlebars template, which could l
 
 ### Configuring a custom form factory
 
-If needed, you can implement your custom form factories und configure them to be used for diffrent pesets indually.
+If needed, you can implement your custom form factories und configure them to be used for diffrent presets indually.
 
 ```yaml
 Neos:
@@ -589,3 +589,5 @@ Neos:
           formFactories:
             myFormPersitenceIdentifier: '\MyVendor\MyPackage\PathTo\MyFormFactory'
 ```
+
+With this configurtion, your custom form factory will be used for generating your custom form when rendering the form for the preview or edit views of the form.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The Form YAML Builder is meant to be extensible, on the following points:
   by subclassing `Neos.Form.YamlBuilder.View.Editor.ValidatorEditor.DefaultValidatorEditor`
 - you can write **new finisher editors** which are displayed underneath the *finishers*, in a process
   similar to creating new validator editors.
+- you can configure your custom form factories for every preset individually
 
 **If you want to extend the form builder, EmberJS and JavaScript knowledge is required.**
 
@@ -228,7 +229,7 @@ formElementTypes:
       formBuilder:
         group: custom
         label: 'Programming Language Select'
-      
+
         # we now set some defaults which are applied once the form element is inserted to the form
         predefinedDefaults:
           properties:
@@ -574,3 +575,17 @@ Now, you only need to include the appropriate Handlebars template, which could l
 
 > **Tip:** Creating a custom *validator editor* works in the same way, just that they have to be registered
    underneath ``validatorPresets`` and the editor is called ``validators`` instead of ``finishers``.
+
+### Configuring a custom form factory
+
+If needed, you can implement your custom form factories und configure them to be used for diffrent pesets indually.
+
+```yaml
+Neos:
+  Form:
+    YamlBuilder:
+      presets:
+        myPreset:
+          formFactories:
+            myFormPersitenceIdentifier: '\MyVendor\MyPackage\PathTo\MyFormFactory'
+```

--- a/Resources/Private/Templates/FormManager/Show.html
+++ b/Resources/Private/Templates/FormManager/Show.html
@@ -13,6 +13,6 @@
 				<f:form.hidden name="formPersistenceIdentifier" value="{formPersistenceIdentifier}" />
 			</f:form>
 		</div>
-		<form:render persistenceIdentifier="{formPersistenceIdentifier}" presetName="{presetName}" />
+		<form:render persistenceIdentifier="{formPersistenceIdentifier}" presetName="{presetName}" factoryClass="{formFactoryClass}"/>
 	</body>
 </html>

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "description": "Graphical User Interface for creating and editing Forms based on the Flow Form Framework",
     "require": {
         "neos/flow": ">=4.1 <7.0 || dev-master",
-        "neos/form": "^4.1"
+        "neos/form": "^4.1 || ^5.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Adds an option to configure a custom form factory. This factory is then used for generating the form definition object which defines the form elements to be rendered. The rendering of the form is handle by the render viewhelper from the neos/form package respectively by the renderformpageAction. The use of the custom form factory allows the developer to add additional data to the form elements e.g. from the data base. In my case, I needed the option to add data about car makers from the project data base to a carmaker form element.